### PR TITLE
Copy /etc/services and /etc/resolv.conf inside postfix's chroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,8 @@ RUN nginx -t
 RUN echo "postfix postfix/mailname string mydomain.net" | debconf-set-selections \
  && echo "postfix postfix/main_mailer_type select Internet Site" | debconf-set-selections \
  && echo "postfix postfix/destinations string mydomain.net, localhost.localdomain, localhost " | debconf-set-selections \
+ && cp /etc/services /var/spool/postfix/etc/
+ && cp /etc/resolv.conf /var/spool/postfix/etc
  && postfix check
 
 # Import Supervisor configuration files.


### PR DESCRIPTION
It seems this postfix package doesn't get configured properly, and in particular services and resolv.conf are not copied inside the postfix chroot. So just copy them by hand during initialization.
