### PR TITLE
Remove import from google

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,8 +83,7 @@ RUN su - couchdb -c 'couchdb -b' \
  && curl -X POST http://localhost:9103/api/instance -H "Content-Type: application/json" -d '{"background":"background-07"}' \
  && for app in calendar contacts photos emails files sync; do \
    cozy-monitor install $app; \
- done \
- && cozy-monitor install import-from-google -r https://github.com/cozy-labs/import-from-google.git
+ done
 
 # Configure Nginx and check its configuration by restarting the service.
 ADD nginx/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Since the application stays in "installing" state, thus is not working. We decided to remove it so the image still works without spending too much time on it.
